### PR TITLE
updated source-deploy-retrieve package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"@salesforce/command": "^4.2.0",
 		"@salesforce/core": "^2.29.0",
 		"@salesforce/plugin-user": "^1.7.0",
-		"@salesforce/source-deploy-retrieve": "^2.2.0",
+		"@salesforce/source-deploy-retrieve": "^6.2.0",
 		"@salesforce/ts-types": "^1.5.20",
 		"chalk": "^4.1.2",
 		"csv-parser": "^2.3.2",


### PR DESCRIPTION
Updated package version that the delta command is dependent on. Previous version was using a metadata registry that was missing newer metadata types, which resulted in some newer metadata types being missed from the generated package xml.